### PR TITLE
Paint Persistence

### DIFF
--- a/Assets/Environment/CombinedObjects/DoubleSidedWall_3m_A.prefab
+++ b/Assets/Environment/CombinedObjects/DoubleSidedWall_3m_A.prefab
@@ -104,8 +104,29 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1718229891699152, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7137080325450624164}
   m_SourcePrefab: {fileID: 100100000, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
+--- !u!1 &7793039238414866248 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1718229891699152, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
+  m_PrefabInstance: {fileID: 7791356399592687256}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7137080325450624164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7793039238414866248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c42b1610e8bafec4cb8e7e32612a7f59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: 
 --- !u!4 &7795590179181812582 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4233851531927038, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
@@ -182,10 +203,31 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1718229891699152, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7723769789640370190}
   m_SourcePrefab: {fileID: 100100000, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
 --- !u!4 &7949099235495199260 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4233851531927038, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
   m_PrefabInstance: {fileID: 7953309702003285986}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &7951614978543619634 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1718229891699152, guid: ffd84ed5789294d47ac95d8054ac98b5, type: 3}
+  m_PrefabInstance: {fileID: 7953309702003285986}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7723769789640370190
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7951614978543619634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c42b1610e8bafec4cb8e7e32612a7f59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: 

--- a/Assets/Environment/LowPolyOfficeProps_FULL/Prefabs/Wall_3m_A.prefab
+++ b/Assets/Environment/LowPolyOfficeProps_FULL/Prefabs/Wall_3m_A.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 23576459500075878}
   - component: {fileID: 64247493734417104}
   - component: {fileID: 1678497783427222432}
+  - component: {fileID: 1699467728683607367}
   m_Layer: 0
   m_Name: Wall_3m_A
   m_TagString: Untagged
@@ -124,3 +125,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _paintableShader: {fileID: 4800000, guid: b8d76d4e901440b2974df15a4e39dcd5, type: 3}
+--- !u!114 &1699467728683607367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1718229891699152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c42b1610e8bafec4cb8e7e32612a7f59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: 

--- a/Assets/Environment/LowPolyOfficeProps_FULL/Prefabs/Wall_3m_A_CornerIN.prefab
+++ b/Assets/Environment/LowPolyOfficeProps_FULL/Prefabs/Wall_3m_A_CornerIN.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 23826733965151878}
   - component: {fileID: 64089814220487100}
   - component: {fileID: 2638871993425502678}
+  - component: {fileID: 5656228665648745859}
   m_Layer: 0
   m_Name: Wall_3m_A_CornerIN
   m_TagString: Untagged
@@ -124,3 +125,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _paintableShader: {fileID: 4800000, guid: b8d76d4e901440b2974df15a4e39dcd5, type: 3}
+--- !u!114 &5656228665648745859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455045004170524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c42b1610e8bafec4cb8e7e32612a7f59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: 

--- a/Assets/Prefabs/PaintTextureManager.prefab
+++ b/Assets/Prefabs/PaintTextureManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6575730570786712536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1816812125654342114}
+  - component: {fileID: 5451698612030313542}
+  m_Layer: 0
+  m_Name: PaintTextureManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1816812125654342114
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6575730570786712536}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.80644, y: 3.7941337, z: -2.0017776}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5451698612030313542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6575730570786712536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08e6c211b62c6b4488d7c580b13c1c29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/PaintTextureManager.prefab.meta
+++ b/Assets/Prefabs/PaintTextureManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a1483b3056bf9d4088e94a8a16daa8d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/paintable box.prefab
+++ b/Assets/Prefabs/paintable box.prefab
@@ -74,6 +74,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c20df6d6a40b614458e0ee74c95aeb3e, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8752674415177523664}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c20df6d6a40b614458e0ee74c95aeb3e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5523939943884389837}
   m_SourcePrefab: {fileID: 100100000, guid: c20df6d6a40b614458e0ee74c95aeb3e, type: 3}
 --- !u!1 &1579830634861298021 stripped
 GameObject:
@@ -114,3 +117,16 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2, y: 1.9999998, z: 1.9999998}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5523939943884389837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1579830634861298021}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c42b1610e8bafec4cb8e7e32612a7f59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _id: 

--- a/Assets/Resources/ProjectScope.prefab
+++ b/Assets/Resources/ProjectScope.prefab
@@ -63,3 +63,4 @@ MonoBehaviour:
   _inputManagerPrefab: {fileID: 1414727366675225165, guid: 8cf088e09cc344ad7a6f973c4e493870, type: 3}
   _taskManagerPrefab: {fileID: 2289974368939544688, guid: 417980af773874e909197ceb42fb6a64, type: 3}
   _uiManagerPrefab: {fileID: 1720066117832891585, guid: 5e1f1d5c361914b44922ffac4add0b08, type: 3}
+  _paintTextureManagerPrefab: {fileID: 6575730570786712536, guid: 4a1483b3056bf9d4088e94a8a16daa8d, type: 3}

--- a/Assets/Scenes/Playground.unity
+++ b/Assets/Scenes/Playground.unity
@@ -344,6 +344,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5523939943884389837, guid: 5a539b98f9d217b4d96fd37193885820, type: 3}
+      propertyPath: _id
+      value: 7f99cf25-bdeb-4827-ac01-2a0a9004a05d
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -854,6 +858,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5523939943884389837, guid: 5a539b98f9d217b4d96fd37193885820, type: 3}
+      propertyPath: _id
+      value: 764fd5d4-2e83-4bb2-9f78-efc05cb4e8bd
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1294,6 +1302,10 @@ PrefabInstance:
     - target: {fileID: 2208874033871608799, guid: 5a539b98f9d217b4d96fd37193885820, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5523939943884389837, guid: 5a539b98f9d217b4d96fd37193885820, type: 3}
+      propertyPath: _id
+      value: 217956c6-52b8-4621-9058-9de7263e1cae
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/FirstPersonController.cs
+++ b/Assets/Scripts/FirstPersonController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.SceneManagement;
 
 [RequireComponent(typeof(CharacterController))]
 [RequireComponent(typeof(PlayerInput))]
@@ -252,6 +253,9 @@ public class FirstPersonController : MonoBehaviour
 
     private void Paint()
     {
+        if (_input.erase)
+            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+        
         if (_input.paint)
             _playerPaint.Paint();
         else if (_input.erase)

--- a/Assets/Scripts/FirstPersonController.cs
+++ b/Assets/Scripts/FirstPersonController.cs
@@ -253,9 +253,6 @@ public class FirstPersonController : MonoBehaviour
 
     private void Paint()
     {
-        if (_input.erase)
-            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
-        
         if (_input.paint)
             _playerPaint.Paint();
         else if (_input.erase)

--- a/Assets/Scripts/GameServiceProvider.cs
+++ b/Assets/Scripts/GameServiceProvider.cs
@@ -10,6 +10,7 @@ public class GameServiceProvider : MonoBehaviour, IInstaller
     [SerializeField] private GameObject _inputManagerPrefab;
     [SerializeField] private GameObject _taskManagerPrefab;
     [SerializeField] private GameObject _uiManagerPrefab;
+    [SerializeField] private GameObject _paintTextureManagerPrefab;
 
     public void InstallBindings(ContainerBuilder builder)
     {
@@ -20,6 +21,7 @@ public class GameServiceProvider : MonoBehaviour, IInstaller
         GameObject inputManagerInstance = Instantiate(_inputManagerPrefab);
         GameObject taskManagerInstance = Instantiate(_taskManagerPrefab);
         GameObject uiManagerInstance = Instantiate(_uiManagerPrefab);
+        GameObject paintTextureManagerInstance = Instantiate(_paintTextureManagerPrefab);
 
         // Bind Global Managers.
         builder.AddSingleton(audioManagerInstance.GetComponent<AudioManager>(), typeof(AudioManager));
@@ -28,6 +30,7 @@ public class GameServiceProvider : MonoBehaviour, IInstaller
         builder.AddSingleton(inputManagerInstance.GetComponent<InputManager>(), typeof(InputManager));
         builder.AddSingleton(taskManagerInstance.GetComponent<TaskManager>(), typeof(TaskManager));
         builder.AddSingleton(uiManagerInstance.GetComponent<UIManager>(), typeof(UIManager));
+        builder.AddSingleton(paintTextureManagerInstance.GetComponent<PaintTextureManager>(), typeof(PaintTextureManager));
 
         // Build the container.
         var container = builder.Build();
@@ -39,5 +42,6 @@ public class GameServiceProvider : MonoBehaviour, IInstaller
         GameObjectInjector.InjectRecursive(inputManagerInstance, container);
         GameObjectInjector.InjectRecursive(taskManagerInstance, container);
         GameObjectInjector.InjectRecursive(uiManagerInstance, container);
+        GameObjectInjector.InjectRecursive(paintTextureManagerInstance, container);
     }
 }

--- a/Assets/Scripts/PaintTextureManager.cs
+++ b/Assets/Scripts/PaintTextureManager.cs
@@ -30,27 +30,25 @@ public class PaintTextureManager : MonoBehaviour
     /// <param name="id">Key in the map</param>
     /// <param name="texture"></param>
     /// <returns>Returns true if texture is already in the map, false otherwise</returns>
-    public bool GetOrCreateTexture(string id, out PaintTexture texture)
+    public bool GetTexture(string id, out PaintTexture texture)
     {
         if (!_textureMap.ContainsKey(id))
         {
-            texture = CreateTexture();
-            _textureMap.Add(id, texture);
+            texture = default(PaintTexture);
             return false;
         }
-
         texture = _textureMap[id];
         return true;
     }
 
-    private PaintTexture CreateTexture()
+    public void CreateTexture(string id, out PaintTexture texture)
     {
-        PaintTexture paintTexture = new()
+        texture = new()
         {
             Mask = new RenderTexture(TEXTURE_SIZE, TEXTURE_SIZE, 0, RenderTextureFormat.Default),
             Support = new RenderTexture(TEXTURE_SIZE, TEXTURE_SIZE, 0, RenderTextureFormat.Default),
         };
         
-        return paintTexture;
+        _textureMap.Add(id, texture);
     }
 }

--- a/Assets/Scripts/PaintTextureManager.cs
+++ b/Assets/Scripts/PaintTextureManager.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PaintTextureManager : MonoBehaviour
+{
+    public struct PaintTexture
+    {
+        public RenderTexture Mask;
+        public RenderTexture Support;
+    }
+    
+    private const int TEXTURE_SIZE = 512;
+
+    private Dictionary<string, PaintTexture> _textureMap;
+
+    private void Awake()
+    {
+        DontDestroyOnLoad(gameObject);
+    }
+    
+    private void OnEnable()
+    {
+        _textureMap = new Dictionary<string, PaintTexture>();
+    }
+
+    /// <summary>
+    /// Gets a texture from the game's texture map
+    /// </summary>
+    /// <param name="id">Key in the map</param>
+    /// <param name="texture"></param>
+    /// <returns>Returns true if texture is already in the map, false otherwise</returns>
+    public bool GetOrCreateTexture(string id, out PaintTexture texture)
+    {
+        if (!_textureMap.ContainsKey(id))
+        {
+            texture = CreateTexture();
+            _textureMap.Add(id, texture);
+            return false;
+        }
+
+        texture = _textureMap[id];
+        return true;
+    }
+
+    private PaintTexture CreateTexture()
+    {
+        PaintTexture paintTexture = new()
+        {
+            Mask = new RenderTexture(TEXTURE_SIZE, TEXTURE_SIZE, 0, RenderTextureFormat.Default),
+            Support = new RenderTexture(TEXTURE_SIZE, TEXTURE_SIZE, 0, RenderTextureFormat.Default),
+        };
+        
+        return paintTexture;
+    }
+}

--- a/Assets/Scripts/PaintTextureManager.cs.meta
+++ b/Assets/Scripts/PaintTextureManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08e6c211b62c6b4488d7c580b13c1c29

--- a/Assets/Scripts/UniqueObject.cs
+++ b/Assets/Scripts/UniqueObject.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using UnityEngine;
+
+public class UniqueObject : MonoBehaviour
+{
+    [SerializeField] private string _id;
+
+    public string Id => _id;
+
+    private void ResetId()
+    {
+        _id = Guid.NewGuid().ToString();
+    }
+
+    public static bool IsUnique(string id)
+    {
+        return Resources.FindObjectsOfTypeAll<UniqueObject>().Count(x => x.Id == id) == 1;
+    }
+
+    private void OnValidate()
+    {
+        // if scene isn't valid, it's probably prefab context
+        if (!gameObject.scene.IsValid())
+        {
+            _id = string.Empty;
+            return;
+        }
+
+        if (string.IsNullOrEmpty(_id) || !IsUnique(_id))
+        {
+            ResetId();
+        }
+    }
+}

--- a/Assets/Scripts/UniqueObject.cs.meta
+++ b/Assets/Scripts/UniqueObject.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c42b1610e8bafec4cb8e7e32612a7f59


### PR DESCRIPTION
Paint is now persisted across scene reloads (and should work when changing to another scene and then back)

- Added `UniqueObject` component that generates GUIDs
- added `PaintTextureManager` that keeps a map of all the paint textures
- Lazy loads paint textures (texture is only created at use, not at start)

closes #30 
closes #34

